### PR TITLE
Improve performance by only using 3 of 4 arguments to toFHIRObject

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -8,7 +8,7 @@ const FHIRv401XML = require('./modelInfos/fhir-modelinfo-4.0.1.xml.js');
 const memoize = (fn) => {
     let cache = new Map();
     return (...args) => {
-       let cacheKey = JSON.stringify([...args]);
+       let cacheKey = JSON.stringify([args[0],args[1],args[3]]);
        if (cache.has(cacheKey)) {
          return cache.get(cacheKey);
        } else {


### PR DESCRIPTION
Improve performance by only using 3 of 4 arguments to toFHIRObject memoize keys.
The 3rd argument to `toFHIRObject` (`modelInfo`) is constant during execution of a CCSM CDS patient, so it can be ignored as part of the memo hash key. This can give ~10% speedup.