### PR TITLE
Fix empty array date time conversion

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -496,7 +496,7 @@ function toSystemObject(data, name) {
       return;
     case 'DateTime':
       // CQL DateTime doesn't support 'Z' right now, so account for that.
-      return cql.DateTime.parse(data.replace('Z', '+00:00'));
+      return cql.DateTime.parse(data) != null ? cql.DateTime.parse(data.replace('Z', '+00:00')) : undefined;
     case 'Date':
       // cql-execution v1.3.2 currently doesn't export the new Date class, so we need to use this workaround
       return cql.DateTime.parse(data) != null ? cql.DateTime.parse(data).getDate() : undefined;

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -496,7 +496,7 @@ function toSystemObject(data, name) {
       return;
     case 'DateTime':
       // CQL DateTime doesn't support 'Z' right now, so account for that.
-      return cql.DateTime.parse(data) != null ? cql.DateTime.parse(data.replace('Z', '+00:00')) : undefined;
+      return typeof data === 'string' ? cql.DateTime.parse(data.replace('Z', '+00:00')) : undefined;
     case 'Date':
       // cql-execution v1.3.2 currently doesn't export the new Date class, so we need to use this workaround
       return cql.DateTime.parse(data) != null ? cql.DateTime.parse(data).getDate() : undefined;


### PR DESCRIPTION
Add a type safety check in the DateTime case of toSystemObject. This protects against the case where a dateTime value is an empty array. Attempting to do a string .replace on an empty array causes an undefined error, which can crash apps like the CDS Dashboard.